### PR TITLE
Fix "Exec format error" issue

### DIFF
--- a/magenx.install.8.sh
+++ b/magenx.install.8.sh
@@ -1596,6 +1596,7 @@ GREENTXT "MAGENTO MALWARE SCANNER"
 YELLOWTXT "Hourly cronjob created"
 pip3 -q install --no-cache-dir --upgrade mwscan
 cat > /etc/cron.hourly/mwscan <<END
+#!/bin/sh
 ## MAGENTO MALWARE SCANNER
 mwscan --newonly --quiet ${MAGE_WEB_ROOT_PATH} | ts | tee -a /var/log/mwscan.log | ifne mailx -s "Malware found at $(hostname)" ${MAGE_ADMIN_EMAIL}
 END


### PR DESCRIPTION
Because `/etc/cron.hourly` lacks the shebang, the cron job fails with

```
/etc/cron.hourly/mwscan:
run-parts: failed to exec /etc/cron.hourly/mwscan: Exec format error
run-parts: /etc/cron.hourly/mwscan exited with return code 1
```

Files in `/etc/cron.XXX` are run by `run-parts`, and they have to be executable and be in the proper format.